### PR TITLE
Async removal

### DIFF
--- a/EssentialApp/EssentialApp/CombineHelpers.swift
+++ b/EssentialApp/EssentialApp/CombineHelpers.swift
@@ -109,7 +109,7 @@ extension Publisher {
 
 private extension FeedCache {
     func saveIgnoringResult(_ feed: [FeedItem]) {
-        save(feed) { _ in }
+        try? save(feed)
     }
     
     func saveIgnoringResult(_ feed: Paginated<FeedItem>) {

--- a/EssentialApp/EssentialApp/CombineHelpers.swift
+++ b/EssentialApp/EssentialApp/CombineHelpers.swift
@@ -180,3 +180,51 @@ extension DispatchQueue {
         }
     }
 }
+
+// MARK: - AnyScheduler
+
+typealias AnyDispatchQueueScheduler = AnyScheduler<DispatchQueue.SchedulerTimeType, DispatchQueue.SchedulerOptions>
+
+extension AnyDispatchQueueScheduler {
+    static var immediateOnMainQueue: Self {
+        DispatchQueue.immediateWhenOnMainQueueScheduler.eraseToAnyScheduler()
+    }
+}
+
+extension Scheduler {
+    func eraseToAnyScheduler() -> AnyScheduler<SchedulerTimeType, SchedulerOptions> {
+        AnyScheduler(self)
+    }
+}
+
+struct AnyScheduler<SchedulerTimeType: Strideable, SchedulerOptions>: Scheduler where SchedulerTimeType.Stride: SchedulerTimeIntervalConvertible {
+    private let _now: () -> SchedulerTimeType
+    private let _minimumTolerance: () -> SchedulerTimeType.Stride
+    private let _schedule: (SchedulerOptions?, @escaping () -> Void) -> Void
+    private let _scheduleAfter: (SchedulerTimeType, SchedulerTimeType.Stride, SchedulerOptions?, @escaping () -> Void) -> Void
+    private let _scheduleAfterInterval: (SchedulerTimeType, SchedulerTimeType.Stride, SchedulerTimeType.Stride, SchedulerOptions?, @escaping () -> Void) -> Cancellable
+    
+    init<S>(_ scheduler: S) where SchedulerTimeType == S.SchedulerTimeType, SchedulerOptions == S.SchedulerOptions, S: Scheduler {
+        _now = { scheduler.now }
+        _minimumTolerance = { scheduler.minimumTolerance }
+        _schedule = scheduler.schedule(options:_:)
+        _scheduleAfter = scheduler.schedule(after:tolerance:options:_:)
+        _scheduleAfterInterval = scheduler.schedule(after:interval:tolerance:options:_:)
+    }
+    
+    var now: SchedulerTimeType { _now() }
+    
+    var minimumTolerance: SchedulerTimeType.Stride { _minimumTolerance() }
+    
+    func schedule(options: SchedulerOptions?, _ action: @escaping () -> Void) {
+        _schedule(options, action)
+    }
+    
+    func schedule(after date: SchedulerTimeType, tolerance: SchedulerTimeType.Stride, options: SchedulerOptions?, _ action: @escaping () -> Void) {
+        _scheduleAfter(date, tolerance, options, action)
+    }
+    
+    func schedule(after date: SchedulerTimeType, interval: SchedulerTimeType.Stride, tolerance: SchedulerTimeType.Stride, options: SchedulerOptions?, _ action: @escaping () -> Void) -> Cancellable {
+        _scheduleAfterInterval(date, interval, tolerance, options, action)
+    }
+}

--- a/EssentialApp/EssentialApp/CombineHelpers.swift
+++ b/EssentialApp/EssentialApp/CombineHelpers.swift
@@ -91,7 +91,9 @@ extension LocalFeedLoader {
     
     func loadPublisher() -> Publisher {
         Deferred {
-            Future(self.load)
+            Future { completion in
+                completion(Result { try self.load() })
+            }
         }
         .eraseToAnyPublisher()
     }

--- a/EssentialApp/EssentialApp/CombineHelpers.swift
+++ b/EssentialApp/EssentialApp/CombineHelpers.swift
@@ -60,15 +60,11 @@ extension FeedImageDataLoader {
     typealias Publisher = AnyPublisher<Data, Error>
     
     func loadPublisher(from url: URL) -> Publisher {
-        var task: FeedImageDataLoaderTask?
-        return Deferred {
+        Deferred {
             Future { completion in
-                task = load(from: url, completion: completion)
+                completion(Result { try load(from: url) })
             }
         }
-        .handleEvents(receiveCancel: {
-            task?.cancel()
-        })
         .eraseToAnyPublisher()
     }
 }
@@ -84,7 +80,7 @@ extension Publisher where Output == Data {
 
 private extension FeedImageDataCache {
     func saveIgnoringResult(data: Data, for url: URL) {
-        save(data, for: url) { _ in }
+        try? save(data, for: url)
     }
 }
 

--- a/EssentialApp/EssentialApp/NullStore.swift
+++ b/EssentialApp/EssentialApp/NullStore.swift
@@ -9,16 +9,16 @@ import Foundation
 import EssentialFeed
 
 final class NullStore: FeedStore & FeedImageDataStore {
-    func deleteCachedFeed(completion: @escaping DeletionCompletion) {
-        completion(nil)
+    func deleteCachedFeed() throws {
+        
     }
     
-    func insert(_ feed: [EssentialFeed.LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
-        completion(nil)
+    func insert(_ feed: [LocalFeedImage], timestamp: Date) throws {
+        
     }
     
-    func retrieve(completion: @escaping RetrievalCompletion) {
-        completion(.success(.none))
+    func retrieve() throws -> CachedFeed? {
+        .none
     }
     
     func insert(_ data: Data, for url: URL) throws {

--- a/EssentialApp/EssentialApp/NullStore.swift
+++ b/EssentialApp/EssentialApp/NullStore.swift
@@ -21,11 +21,11 @@ final class NullStore: FeedStore & FeedImageDataStore {
         completion(.success(.none))
     }
     
-    func insert(_ data: Data, for url: URL, completion: @escaping (InsertionResult) -> Void) {
-        completion(.success(()))
+    func insert(_ data: Data, for url: URL) throws {
+        
     }
     
-    func retrieve(dataForURL url: URL, completion: @escaping (FeedImageDataStore.RetrievalResult) -> Void) {
-        completion(.success(.none))
+    func retrieve(dataForURL url: URL) throws -> Data? {
+        .none
     }
 }

--- a/EssentialApp/EssentialApp/SceneDelegate.swift
+++ b/EssentialApp/EssentialApp/SceneDelegate.swift
@@ -111,6 +111,22 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             .eraseToAnyPublisher()
     }
     
+    /// This is an exercise to demonstrate how we can load first from cache and then load from remote (unused)
+//    private func makeLocalFeedLoaderWithRemoteContinuation() -> AnyPublisher<Paginated<FeedItem>, Error> {
+//        let cachePublisher = localFeedLoader
+//            .loadPublisher()
+//            .map { self.makePage(items: $0, last: nil) }
+//        
+//        let remotePublisher = makeRemoteFeedLoaderWithLocalFallback()
+//            .delay(for: 10, scheduler: DispatchQueue.main)
+//        
+//        let combinedPublisher = cachePublisher
+//            .append(remotePublisher)
+//            .eraseToAnyPublisher()
+//        
+//        return combinedPublisher
+//    }
+    
     private func makeRemoteFeedLoaderWithLocalFallback() -> AnyPublisher<Paginated<FeedItem>, Error> {
         makeRemoteFeedLoader()
             .caching(to: localFeedLoader)

--- a/EssentialApp/EssentialApp/SceneDelegate.swift
+++ b/EssentialApp/EssentialApp/SceneDelegate.swift
@@ -132,6 +132,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             .caching(to: localFeedLoader)
             .fallback(to: localFeedLoader.loadPublisher)
             .map(makeFirstPage)
+            .subscribe(on: coreDataQueue)
             .eraseToAnyPublisher()
     }
     
@@ -144,6 +145,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             }
             .map(makePage)
             .caching(to: localFeedLoader)
+            .subscribe(on: coreDataQueue)
             .eraseToAnyPublisher()
     }
     

--- a/EssentialApp/EssentialApp/SceneDelegate.swift
+++ b/EssentialApp/EssentialApp/SceneDelegate.swift
@@ -52,16 +52,21 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     private lazy var logger = Logger(subsystem: "com.alexdmotoc.EssentialFeed", category: "main")
     
-    private lazy var coreDataQueue: some Scheduler = DispatchQueue(
+    private lazy var coreDataQueue: AnyDispatchQueueScheduler = DispatchQueue(
         label: "com.alexdmotoc.coreDataQueue",
         qos: .userInitiated,
         attributes: .concurrent
-    )
+    ).eraseToAnyScheduler()
     
-    convenience init(httpClient: HTTPClient, store: FeedStore & FeedImageDataStore) {
+    convenience init(
+        httpClient: HTTPClient,
+        store: FeedStore & FeedImageDataStore,
+        coreDataQueue: AnyDispatchQueueScheduler
+    ) {
         self.init()
         self.httpClient = httpClient
         self.store = store
+        self.coreDataQueue = coreDataQueue
     }
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {

--- a/EssentialApp/EssentialApp/SceneDelegate.swift
+++ b/EssentialApp/EssentialApp/SceneDelegate.swift
@@ -83,7 +83,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
     func sceneWillResignActive(_ scene: UIScene) {
-        localFeedLoader.validateCache { _ in }
+        try? localFeedLoader.validateCache()
     }
     
     // MARK: - Navigation

--- a/EssentialApp/EssentialApp/SceneDelegate.swift
+++ b/EssentialApp/EssentialApp/SceneDelegate.swift
@@ -52,6 +52,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     private lazy var logger = Logger(subsystem: "com.alexdmotoc.EssentialFeed", category: "main")
     
+    private lazy var coreDataQueue: some Scheduler = DispatchQueue(
+        label: "com.alexdmotoc.coreDataQueue",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
+    
     convenience init(httpClient: HTTPClient, store: FeedStore & FeedImageDataStore) {
         self.init()
         self.httpClient = httpClient
@@ -138,6 +144,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
                     .getPublisher(at: url)
                     .tryMap(FeedImageDataMapper.map)
                     .caching(to: localFeedImageLoader, for: url)
+                    .subscribe(on: coreDataQueue)
+                    .eraseToAnyPublisher()
             })
+            .subscribe(on: coreDataQueue)
+            .eraseToAnyPublisher()
     }
 }

--- a/EssentialApp/EssentialAppTests/FeedAcceptanceTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedAcceptanceTests.swift
@@ -84,7 +84,7 @@ final class FeedAcceptanceTests: XCTestCase {
     // MARK: - Helpers
     
     private func launch(client: HTTPClientStub, store: InMemoryFeedStore) -> ListViewController {
-        let scene = SceneDelegate(httpClient: client, store: store)
+        let scene = SceneDelegate(httpClient: client, store: store, coreDataQueue: .immediateOnMainQueue)
         scene.window = UIWindow(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
         scene.configureWindow()
         let nav = scene.window?.rootViewController as? UINavigationController
@@ -105,7 +105,7 @@ final class FeedAcceptanceTests: XCTestCase {
     }
     
     private func enterBackground(with store: InMemoryFeedStore) {
-        let sut = SceneDelegate(httpClient: HTTPClientStub.offline, store: store)
+        let sut = SceneDelegate(httpClient: HTTPClientStub.offline, store: store, coreDataQueue: .immediateOnMainQueue)
         sut.sceneWillResignActive(UIApplication.shared.connectedScenes.first!)
     }
     

--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -567,6 +567,22 @@ final class FeedUIIntegrationTests: XCTestCase {
         XCTAssertEqual(view0.isShowingLoadingIndicator, false, "Expected no loading indicator after image preloads successfully")
     }
     
+    func test_feedImageView_displaysCorrectlyWhenPreviousCellIsReused() {
+        let (sut, loader) = makeSUT()
+        sut.simulateAppearance()
+        loader.completeFeedLoad(withFeed: [makeImage()])
+        
+        sut.simulateCellIsVisible(at: 0)
+        let previousView = sut.simulateCellIsNotVisible(at: 0)
+        let newView = sut.simulateCellIsVisible(at: 0)
+        previousView.prepareForReuse()
+        
+        let imageData = UIImage.make(withColor: .red).pngData()!
+        loader.completeImageLoad(withData: imageData, at: 1)
+        
+        XCTAssertEqual(newView.renderedImageData, imageData)
+    }
+    
     // MARK: - Helpers
     
     private struct DummyView: ResourceView {

--- a/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/FeedUIIntegrationTests.swift
@@ -581,7 +581,7 @@ final class FeedUIIntegrationTests: XCTestCase {
         let loader = LoaderSpy()
         let sut = FeedUIComposer.makeFeedController(
             with: loader.loadPublisher,
-            imageLoader: loader.loadPublisher,
+            imageLoader: loader.imageLoadPublisher,
             selection: selection
         )
         checkIsDeallocated(sut: loader, file: file, line: line)

--- a/EssentialApp/EssentialAppTests/Helpers/InMemoryFeedStore.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/InMemoryFeedStore.swift
@@ -18,18 +18,16 @@ class InMemoryFeedStore {
 }
 
 extension InMemoryFeedStore: FeedStore {
-    func deleteCachedFeed(completion: @escaping FeedStore.DeletionCompletion) {
+    func deleteCachedFeed() throws {
         feedCache = nil
-        completion(nil)
     }
-
-    func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping FeedStore.InsertionCompletion) {
+    
+    func insert(_ feed: [LocalFeedImage], timestamp: Date) throws {
         feedCache = CachedFeed(feed: feed, timestamp: timestamp)
-        completion(nil)
     }
-
-    func retrieve(completion: @escaping FeedStore.RetrievalCompletion) {
-        completion(.success(feedCache))
+    
+    func retrieve() throws -> CachedFeed? {
+        feedCache
     }
 }
 

--- a/EssentialApp/EssentialAppTests/Helpers/InMemoryFeedStore.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/InMemoryFeedStore.swift
@@ -34,13 +34,12 @@ extension InMemoryFeedStore: FeedStore {
 }
 
 extension InMemoryFeedStore: FeedImageDataStore {
-    func insert(_ data: Data, for url: URL, completion: @escaping (FeedImageDataStore.InsertionResult) -> Void) {
+    func insert(_ data: Data, for url: URL) throws {
         feedImageDataCache[url] = data
-        completion(.success(()))
     }
-
-    func retrieve(dataForURL url: URL, completion: @escaping (FeedImageDataStore.RetrievalResult) -> Void) {
-        completion(.success(feedImageDataCache[url]))
+    
+    func retrieve(dataForURL url: URL) throws -> Data? {
+        feedImageDataCache[url]
     }
 }
 

--- a/EssentialFeed/Feed cache/CoreData/CoreDataFeedStore+FeedImageDataStore.swift
+++ b/EssentialFeed/Feed cache/CoreData/CoreDataFeedStore+FeedImageDataStore.swift
@@ -9,7 +9,7 @@ import CoreData
 
 extension CoreDataFeedStore: FeedImageDataStore {
     public func insert(_ data: Data, for url: URL, completion: @escaping (FeedImageDataStore.InsertionResult) -> Void) {
-        perform { context in
+        performAsync { context in
             completion(Result {
                 try FeedItemMO.first(with: url, in: context)
                     .map { $0.imageData = data }
@@ -19,7 +19,7 @@ extension CoreDataFeedStore: FeedImageDataStore {
     }
     
     public func retrieve(dataForURL url: URL, completion: @escaping (FeedImageDataStore.RetrievalResult) -> Void) {
-        perform { context in
+        performAsync { context in
             completion(Result {
                 try FeedItemMO.data(with: url, in: context)
             })

--- a/EssentialFeed/Feed cache/CoreData/CoreDataFeedStore+FeedImageDataStore.swift
+++ b/EssentialFeed/Feed cache/CoreData/CoreDataFeedStore+FeedImageDataStore.swift
@@ -8,21 +8,21 @@
 import CoreData
 
 extension CoreDataFeedStore: FeedImageDataStore {
-    public func insert(_ data: Data, for url: URL, completion: @escaping (FeedImageDataStore.InsertionResult) -> Void) {
-        performAsync { context in
-            completion(Result {
+    public func insert(_ data: Data, for url: URL) throws {
+        try performSync { context in
+            Result {
                 try FeedItemMO.first(with: url, in: context)
                     .map { $0.imageData = data }
                     .map(context.save)
-            })
+            }
         }
     }
     
-    public func retrieve(dataForURL url: URL, completion: @escaping (FeedImageDataStore.RetrievalResult) -> Void) {
-        performAsync { context in
-            completion(Result {
+    public func retrieve(dataForURL url: URL) throws -> Data? {
+        try performSync { context in
+            Result {
                 try FeedItemMO.data(with: url, in: context)
-            })
+            }
         }
     }
 }

--- a/EssentialFeed/Feed cache/CoreData/CoreDataFeedStore+FeedStore.swift
+++ b/EssentialFeed/Feed cache/CoreData/CoreDataFeedStore+FeedStore.swift
@@ -9,7 +9,7 @@ import Foundation
 
 extension CoreDataFeedStore: FeedStore {
     public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
-        perform { context in
+        performAsync { context in
             let request = FeedCacheMO.fetchRequest()
             do {
                 let results = try context.fetch(request)
@@ -23,7 +23,7 @@ extension CoreDataFeedStore: FeedStore {
     }
     
     public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
-        perform { context in
+        performAsync { context in
             do {
                 let existingCache = try context.fetch(FeedCacheMO.fetchRequest())
                 for item in existingCache { context.delete(item) }
@@ -52,7 +52,7 @@ extension CoreDataFeedStore: FeedStore {
     }
     
     public func retrieve(completion: @escaping RetrievalCompletion) {
-        perform { context in
+        performAsync { context in
             completion(Result {
                 try context.fetch(FeedCacheMO.fetchRequest()).first.map {
                     ($0.localFeed, $0.timestamp!)

--- a/EssentialFeed/Feed cache/CoreData/CoreDataFeedStore+FeedStore.swift
+++ b/EssentialFeed/Feed cache/CoreData/CoreDataFeedStore+FeedStore.swift
@@ -8,23 +8,21 @@
 import Foundation
 
 extension CoreDataFeedStore: FeedStore {
-    public func deleteCachedFeed(completion: @escaping DeletionCompletion) {
-        performAsync { context in
-            let request = FeedCacheMO.fetchRequest()
-            do {
+    
+    public func deleteCachedFeed() throws {
+        try performSync { context in
+            Result {
+                let request = FeedCacheMO.fetchRequest()
                 let results = try context.fetch(request)
                 for item in results { context.delete(item) }
                 try context.save()
-                completion(nil)
-            } catch {
-                completion(error)
             }
         }
     }
     
-    public func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {
-        performAsync { context in
-            do {
+    public func insert(_ feed: [LocalFeedImage], timestamp: Date) throws {
+        try performSync { context in
+            Result {
                 let existingCache = try context.fetch(FeedCacheMO.fetchRequest())
                 for item in existingCache { context.delete(item) }
                 
@@ -44,20 +42,17 @@ extension CoreDataFeedStore: FeedStore {
                 feedMO.forEach { cache.addToFeed($0) }
                 cache.timestamp = timestamp
                 try context.save()
-                completion(nil)
-            } catch {
-                completion(error)
             }
         }
     }
     
-    public func retrieve(completion: @escaping RetrievalCompletion) {
-        performAsync { context in
-            completion(Result {
+    public func retrieve() throws -> CachedFeed? {
+        try performSync { context in
+            Result {
                 try context.fetch(FeedCacheMO.fetchRequest()).first.map {
                     ($0.localFeed, $0.timestamp!)
                 }
-            })
+            }
         }
     }
 }

--- a/EssentialFeed/Feed cache/CoreData/CoreDataFeedStore.swift
+++ b/EssentialFeed/Feed cache/CoreData/CoreDataFeedStore.swift
@@ -32,7 +32,7 @@ public final class CoreDataFeedStore {
         }
     }
 
-    func perform(_ action: @escaping (NSManagedObjectContext) -> Void) {
+    func performAsync(_ action: @escaping (NSManagedObjectContext) -> Void) {
         let context = self.context
         context.perform { action(context) }
     }

--- a/EssentialFeed/Feed cache/CoreData/CoreDataFeedStore.swift
+++ b/EssentialFeed/Feed cache/CoreData/CoreDataFeedStore.swift
@@ -37,6 +37,13 @@ public final class CoreDataFeedStore {
         context.perform { action(context) }
     }
     
+    func performSync<R>(_ action: (NSManagedObjectContext) -> Result<R, Error>) throws -> R {
+        let result = context.performAndWait { [context] in
+            action(context)
+        }
+        return try result.get()
+    }
+    
     private func cleanUpReferencesToPersistentStores() {
         context.performAndWait {
             let coordinator = self.container.persistentStoreCoordinator

--- a/EssentialFeed/Feed cache/FeedImageDataStore.swift
+++ b/EssentialFeed/Feed cache/FeedImageDataStore.swift
@@ -8,44 +8,6 @@
 import Foundation
 
 public protocol FeedImageDataStore {
-    typealias RetrievalResult = Swift.Result<Data?, Error>
-    typealias InsertionResult = Swift.Result<Void, Error>
-    
-    @available(*, deprecated)
-    func insert(_ data: Data, for url: URL, completion: @escaping (InsertionResult) -> Void)
-    
-    @available(*, deprecated)
-    func retrieve(dataForURL url: URL, completion: @escaping (RetrievalResult) -> Void)
-    
     func insert(_ data: Data, for url: URL) throws
     func retrieve(dataForURL url: URL) throws -> Data?
-}
-
-public extension FeedImageDataStore {
-    func insert(_ data: Data, for url: URL) throws {
-        let group = DispatchGroup()
-        var receivedResult: InsertionResult!
-        group.enter()
-        insert(data, for: url) { result in
-            receivedResult = result
-            group.leave()
-        }
-        group.wait()
-        return try receivedResult.get()
-    }
-    
-    func retrieve(dataForURL url: URL) throws -> Data? {
-        let group = DispatchGroup()
-        var receivedResult: RetrievalResult!
-        group.enter()
-        retrieve(dataForURL: url) { result in
-            receivedResult = result
-            group.leave()
-        }
-        group.wait()
-        return try receivedResult.get()
-    }
-    
-    func insert(_ data: Data, for url: URL, completion: @escaping (InsertionResult) -> Void) {}
-    func retrieve(dataForURL url: URL, completion: @escaping (RetrievalResult) -> Void) {}
 }

--- a/EssentialFeed/Feed cache/FeedImageDataStore.swift
+++ b/EssentialFeed/Feed cache/FeedImageDataStore.swift
@@ -11,6 +11,41 @@ public protocol FeedImageDataStore {
     typealias RetrievalResult = Swift.Result<Data?, Error>
     typealias InsertionResult = Swift.Result<Void, Error>
     
+    @available(*, deprecated)
     func insert(_ data: Data, for url: URL, completion: @escaping (InsertionResult) -> Void)
+    
+    @available(*, deprecated)
     func retrieve(dataForURL url: URL, completion: @escaping (RetrievalResult) -> Void)
+    
+    func insert(_ data: Data, for url: URL) throws
+    func retrieve(dataForURL url: URL) throws -> Data?
+}
+
+public extension FeedImageDataStore {
+    func insert(_ data: Data, for url: URL) throws {
+        let group = DispatchGroup()
+        var receivedResult: InsertionResult!
+        group.enter()
+        insert(data, for: url) { result in
+            receivedResult = result
+            group.leave()
+        }
+        group.wait()
+        return try receivedResult.get()
+    }
+    
+    func retrieve(dataForURL url: URL) throws -> Data? {
+        let group = DispatchGroup()
+        var receivedResult: RetrievalResult!
+        group.enter()
+        retrieve(dataForURL: url) { result in
+            receivedResult = result
+            group.leave()
+        }
+        group.wait()
+        return try receivedResult.get()
+    }
+    
+    func insert(_ data: Data, for url: URL, completion: @escaping (InsertionResult) -> Void) {}
+    func retrieve(dataForURL url: URL, completion: @escaping (RetrievalResult) -> Void) {}
 }

--- a/EssentialFeed/Feed cache/FeedStore.swift
+++ b/EssentialFeed/Feed cache/FeedStore.swift
@@ -10,68 +10,7 @@ import Foundation
 public typealias CachedFeed = (feed: [LocalFeedImage], timestamp: Date)
 
 public protocol FeedStore {
-    typealias DeletionCompletion = (Error?) -> Void
-    typealias InsertionCompletion = (Error?) -> Void
-    
-    typealias RetrievalResult = Result<CachedFeed?, Error>
-    typealias RetrievalCompletion = (RetrievalResult) -> Void
-    
-    @available(*, deprecated)
-    func deleteCachedFeed(completion: @escaping DeletionCompletion)
-    
-    @available(*, deprecated)
-    func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion)
-    
-    @available(*, deprecated)
-    func retrieve(completion: @escaping RetrievalCompletion)
-    
     func deleteCachedFeed() throws
     func insert(_ feed: [LocalFeedImage], timestamp: Date) throws
     func retrieve() throws -> CachedFeed?
-}
-
-public extension FeedStore {
-    func deleteCachedFeed() throws {
-        let group = DispatchGroup()
-        var receivedError: Error?
-        group.enter()
-        deleteCachedFeed { error in
-            receivedError = error
-            group.leave()
-        }
-        group.wait()
-        if let receivedError {
-            throw receivedError
-        }
-    }
-    
-    func insert(_ feed: [LocalFeedImage], timestamp: Date) throws {
-        let group = DispatchGroup()
-        var receivedError: Error?
-        group.enter()
-        insert(feed, timestamp: timestamp) { error in
-            receivedError = error
-            group.leave()
-        }
-        group.wait()
-        if let receivedError {
-            throw receivedError
-        }
-    }
-    
-    func retrieve() throws -> CachedFeed? {
-        let group = DispatchGroup()
-        var received: RetrievalResult!
-        group.enter()
-        retrieve { result in
-            received = result
-            group.leave()
-        }
-        group.wait()
-        return try received.get()
-    }
-    
-    func deleteCachedFeed(completion: @escaping DeletionCompletion) {}
-    func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {}
-    func retrieve(completion: @escaping RetrievalCompletion) {}
 }

--- a/EssentialFeed/Feed cache/FeedStore.swift
+++ b/EssentialFeed/Feed cache/FeedStore.swift
@@ -70,4 +70,8 @@ public extension FeedStore {
         group.wait()
         return try received.get()
     }
+    
+    func deleteCachedFeed(completion: @escaping DeletionCompletion) {}
+    func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion) {}
+    func retrieve(completion: @escaping RetrievalCompletion) {}
 }

--- a/EssentialFeed/Feed cache/FeedStore.swift
+++ b/EssentialFeed/Feed cache/FeedStore.swift
@@ -16,7 +16,58 @@ public protocol FeedStore {
     typealias RetrievalResult = Result<CachedFeed?, Error>
     typealias RetrievalCompletion = (RetrievalResult) -> Void
     
+    @available(*, deprecated)
     func deleteCachedFeed(completion: @escaping DeletionCompletion)
+    
+    @available(*, deprecated)
     func insert(_ feed: [LocalFeedImage], timestamp: Date, completion: @escaping InsertionCompletion)
+    
+    @available(*, deprecated)
     func retrieve(completion: @escaping RetrievalCompletion)
+    
+    func deleteCachedFeed() throws
+    func insert(_ feed: [LocalFeedImage], timestamp: Date) throws
+    func retrieve() throws -> CachedFeed?
+}
+
+public extension FeedStore {
+    func deleteCachedFeed() throws {
+        let group = DispatchGroup()
+        var receivedError: Error?
+        group.enter()
+        deleteCachedFeed { error in
+            receivedError = error
+            group.leave()
+        }
+        group.wait()
+        if let receivedError {
+            throw receivedError
+        }
+    }
+    
+    func insert(_ feed: [LocalFeedImage], timestamp: Date) throws {
+        let group = DispatchGroup()
+        var receivedError: Error?
+        group.enter()
+        insert(feed, timestamp: timestamp) { error in
+            receivedError = error
+            group.leave()
+        }
+        group.wait()
+        if let receivedError {
+            throw receivedError
+        }
+    }
+    
+    func retrieve() throws -> CachedFeed? {
+        let group = DispatchGroup()
+        var received: RetrievalResult!
+        group.enter()
+        retrieve { result in
+            received = result
+            group.leave()
+        }
+        group.wait()
+        return try received.get()
+    }
 }

--- a/EssentialFeed/Feed cache/LocalFeedImageDataLoader.swift
+++ b/EssentialFeed/Feed cache/LocalFeedImageDataLoader.swift
@@ -57,15 +57,13 @@ extension LocalFeedImageDataLoader: FeedImageDataLoader {
     
     public func load(from url: URL, completion: @escaping (LoadResult) -> Void) -> FeedImageDataLoaderTask {
         let task = LoadImageDataTask(completion: completion)
-        store.retrieve(dataForURL: url) { [weak self] result in
-            guard self != nil else { return }
-            task.complete(with: result
+        task.complete(
+            with: Swift.Result { try store.retrieve(dataForURL: url) }
                 .mapError { _ in LoadError.failed }
                 .flatMap { data in
                     data.map { .success($0) } ?? .failure(LoadError.notFound)
                 }
-            )
-        }
+        )
         return task
     }
 }

--- a/EssentialFeed/Feed cache/LocalFeedImageDataLoader.swift
+++ b/EssentialFeed/Feed cache/LocalFeedImageDataLoader.swift
@@ -24,11 +24,9 @@ extension LocalFeedImageDataLoader: FeedImageDataCache {
     }
     
     public func save(_ data: Data, for url: URL, completion: @escaping (SaveResult) -> Void) {
-        store.insert(data, for: url) { [weak self] result in
-            guard self != nil else { return }
-            
-            completion(result.mapError { _ in SaveError.failed })
-        }
+        completion(Swift.Result {
+            try store.insert(data, for: url)
+        }.mapError({ _ in SaveError.failed }))
     }
 }
 

--- a/EssentialFeed/Feed cache/LocalFeedImageDataLoader.swift
+++ b/EssentialFeed/Feed cache/LocalFeedImageDataLoader.swift
@@ -17,16 +17,16 @@ public class LocalFeedImageDataLoader {
 }
 
 extension LocalFeedImageDataLoader: FeedImageDataCache {
-    public typealias SaveResult = Result<Void, Error>
-    
     public enum SaveError: Error {
         case failed
     }
     
-    public func save(_ data: Data, for url: URL, completion: @escaping (SaveResult) -> Void) {
-        completion(Swift.Result {
+    public func save(_ data: Data, for url: URL) throws {
+        do {
             try store.insert(data, for: url)
-        }.mapError({ _ in SaveError.failed }))
+        } catch {
+            throw SaveError.failed
+        }
     }
 }
 

--- a/EssentialFeed/Feed cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed cache/LocalFeedLoader.swift
@@ -34,20 +34,16 @@ extension LocalFeedLoader {
 }
 
 extension LocalFeedLoader {
-    public typealias ValidationResult = Result<Void, Error>
-    
     private struct InvalidCacheError: Error {}
     
-    public func validateCache(completion: @escaping (ValidationResult) -> Void) {
-        completion(ValidationResult {
-            do {
-                if let cache = try store.retrieve(), !FeedCachePolicy.validate(cache.timestamp, against: currentDate()) {
-                    throw InvalidCacheError()
-                }
-            } catch {
-                try store.deleteCachedFeed()
+    public func validateCache() throws {
+        do {
+            if let cache = try store.retrieve(), !FeedCachePolicy.validate(cache.timestamp, against: currentDate()) {
+                throw InvalidCacheError()
             }
-        })
+        } catch {
+            try store.deleteCachedFeed()
+        }
     }
 }
 

--- a/EssentialFeed/Feed cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed cache/LocalFeedLoader.swift
@@ -25,13 +25,11 @@ extension LocalFeedLoader: FeedCache {
 }
 
 extension LocalFeedLoader {
-    public func load(completion: @escaping (Result<[FeedItem], Error>) -> Void) {
-        completion(Result {
-            if let cache = try store.retrieve(), FeedCachePolicy.validate(cache.timestamp, against: currentDate()) {
-                return cache.feed.toModels()
-            }
-            return []
-        })
+    public func load() throws -> [FeedItem] {
+        if let cache = try store.retrieve(), FeedCachePolicy.validate(cache.timestamp, against: currentDate()) {
+            return cache.feed.toModels()
+        }
+        return []
     }
 }
 

--- a/EssentialFeed/Feed cache/LocalFeedLoader.swift
+++ b/EssentialFeed/Feed cache/LocalFeedLoader.swift
@@ -18,15 +18,9 @@ public final class LocalFeedLoader {
 }
 
 extension LocalFeedLoader: FeedCache {
-    public func save(_ feed: [FeedItem], completion: @escaping (Error?) -> Void) {
-        var receivedError: Error?
-        do {
-            try store.deleteCachedFeed()
-            try store.insert(feed.toLocal(), timestamp: currentDate())
-        } catch {
-            receivedError = error
-        }
-        completion(receivedError)
+    public func save(_ feed: [FeedItem]) throws {
+        try store.deleteCachedFeed()
+        try store.insert(feed.toLocal(), timestamp: currentDate())
     }
 }
 

--- a/EssentialFeed/Feed feature/FeedCache.swift
+++ b/EssentialFeed/Feed feature/FeedCache.swift
@@ -8,5 +8,5 @@
 import Foundation
 
 public protocol FeedCache {
-    func save(_ feed: [FeedItem], completion: @escaping (Error?) -> Void)
+    func save(_ feed: [FeedItem]) throws
 }

--- a/EssentialFeed/Feed feature/FeedImageDataCache.swift
+++ b/EssentialFeed/Feed feature/FeedImageDataCache.swift
@@ -8,7 +8,5 @@
 import Foundation
 
 public protocol FeedImageDataCache {
-    typealias SaveResult = Result<Void, Error>
-    
-    func save(_ data: Data, for url: URL, completion: @escaping (SaveResult) -> Void)
+    func save(_ data: Data, for url: URL) throws
 }

--- a/EssentialFeed/Feed feature/FeedImageDataLoader.swift
+++ b/EssentialFeed/Feed feature/FeedImageDataLoader.swift
@@ -7,11 +7,6 @@
 
 import Foundation
 
-public protocol FeedImageDataLoaderTask {
-    func cancel()
-}
-
 public protocol FeedImageDataLoader {
-    typealias Result = Swift.Result<Data, Error>
-    func load(from url: URL, completion: @escaping (Result) -> Void) -> FeedImageDataLoaderTask
+    func load(from url: URL) throws -> Data
 }

--- a/EssentialFeedCacheIntegrationTests/EssentialFeedCacheIntegrationTests.swift
+++ b/EssentialFeedCacheIntegrationTests/EssentialFeedCacheIntegrationTests.swift
@@ -168,30 +168,20 @@ class EssentialFeedCacheIntegrationTests: XCTestCase {
     }
     
     private func save(_ data: Data, for url: URL, with loader: LocalFeedImageDataLoader, file: StaticString = #file, line: UInt = #line) {
-        let saveExp = expectation(description: "Wait for save completion")
-        loader.save(data, for: url) { result in
-            if case let Result.failure(error) = result {
-                XCTFail("Expected to save image data successfully, got error: \(error)", file: file, line: line)
-            }
-            saveExp.fulfill()
+        do {
+            try loader.save(data, for: url)
+        } catch {
+            XCTFail("Expected to save image data successfully, got error: \(error)", file: file, line: line)
         }
-        wait(for: [saveExp], timeout: 1.0)
     }
     
     private func expect(_ sut: LocalFeedImageDataLoader, toLoad expectedData: Data, for url: URL, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-        _ = sut.load(from: url) { result in
-            switch result {
-            case let .success(loadedData):
-                XCTAssertEqual(loadedData, expectedData, file: file, line: line)
-                
-            case let .failure(error):
-                XCTFail("Expected successful image data result, got \(error) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
+        do {
+            let loadedData = try sut.load(from: url)
+            XCTAssertEqual(loadedData, expectedData, file: file, line: line)
+        } catch {
+            XCTFail("Expected successful image data result, got \(error) instead", file: file, line: line)
         }
-        wait(for: [exp], timeout: 1.0)
     }
     
     private func setupEmptyStoreState() {
@@ -213,5 +203,4 @@ class EssentialFeedCacheIntegrationTests: XCTestCase {
     private func cachesDirectory() -> URL {
         return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
     }
-
 }

--- a/EssentialFeedCacheIntegrationTests/EssentialFeedCacheIntegrationTests.swift
+++ b/EssentialFeedCacheIntegrationTests/EssentialFeedCacheIntegrationTests.swift
@@ -130,14 +130,11 @@ class EssentialFeedCacheIntegrationTests: XCTestCase {
     }
     
     private func save(_ feed: [FeedItem], with loader: LocalFeedLoader, file: StaticString = #file, line: UInt = #line) {
-        let saveExp = expectation(description: "Wait for save completion")
-        loader.save(feed) { error in
-            if let error {
-                XCTFail("Expected to save feed successfully, got error: \(error)", file: file, line: line)
-            }
-            saveExp.fulfill()
+        do {
+            try loader.save(feed)
+        } catch {
+            XCTFail("Expected to save feed successfully, got error: \(error)", file: file, line: line)
         }
-        wait(for: [saveExp], timeout: 1.0)
     }
     
     private func validateCache(with loader: LocalFeedLoader, file: StaticString = #file, line: UInt = #line) {

--- a/EssentialFeedCacheIntegrationTests/EssentialFeedCacheIntegrationTests.swift
+++ b/EssentialFeedCacheIntegrationTests/EssentialFeedCacheIntegrationTests.swift
@@ -149,19 +149,12 @@ class EssentialFeedCacheIntegrationTests: XCTestCase {
     }
 
     private func expect(_ sut: LocalFeedLoader, toLoad expectedFeed: [FeedItem], file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for load completion")
-        sut.load { result in
-            switch result {
-            case let .success(loadedFeed):
-                XCTAssertEqual(loadedFeed, expectedFeed, file: file, line: line)
-                
-            case let .failure(error):
-                XCTFail("Expected successful feed result, got \(error) instead", file: file, line: line)
-            }
-            
-            exp.fulfill()
+        do {
+            let loadedFeed = try sut.load()
+            XCTAssertEqual(loadedFeed, expectedFeed, file: file, line: line)
+        } catch {
+            XCTFail("Expected successful feed result, got \(error) instead", file: file, line: line)
         }
-        wait(for: [exp], timeout: 1.0)
     }
     
     private func save(_ data: Data, for url: URL, with loader: LocalFeedImageDataLoader, file: StaticString = #file, line: UInt = #line) {

--- a/EssentialFeedCacheIntegrationTests/EssentialFeedCacheIntegrationTests.swift
+++ b/EssentialFeedCacheIntegrationTests/EssentialFeedCacheIntegrationTests.swift
@@ -138,14 +138,11 @@ class EssentialFeedCacheIntegrationTests: XCTestCase {
     }
     
     private func validateCache(with loader: LocalFeedLoader, file: StaticString = #file, line: UInt = #line) {
-        let saveExp = expectation(description: "Wait for save completion")
-        loader.validateCache() { result in
-            if case let Result.failure(error) = result {
-                XCTFail("Expected to validate feed successfully, got error: \(error)", file: file, line: line)
-            }
-            saveExp.fulfill()
+        do {
+            try loader.validateCache()
+        } catch {
+            XCTFail("Expected to validate feed successfully, got error: \(error)", file: file, line: line)
         }
-        wait(for: [saveExp], timeout: 1.0)
     }
 
     private func expect(_ sut: LocalFeedLoader, toLoad expectedFeed: [FeedItem], file: StaticString = #file, line: UInt = #line) {

--- a/EssentialFeedTests/Feed cache/CoreData/CoreDataFeedImageDataStoreTests.swift
+++ b/EssentialFeedTests/Feed cache/CoreData/CoreDataFeedImageDataStoreTests.swift
@@ -9,116 +9,100 @@ import XCTest
 import EssentialFeed
 
 final class CoreDataFeedImageDataStoreTests: XCTestCase {
-
+    
     func test_retrieveImageData_deliversNotFoundWhenEmpty() {
-            let sut = makeSUT()
-
-            expect(sut, toCompleteRetrievalWith: notFound(), for: anyURL())
-        }
-
-        func test_retrieveImageData_deliversNotFoundWhenStoredDataURLDoesNotMatch() {
-            let sut = makeSUT()
-            let url = URL(string: "http://a-url.com")!
-            let nonMatchingURL = URL(string: "http://another-url.com")!
-
-            insert(anyData(), for: url, into: sut)
-
-            expect(sut, toCompleteRetrievalWith: notFound(), for: nonMatchingURL)
-        }
-
-        func test_retrieveImageData_deliversFoundDataWhenThereIsAStoredImageDataMatchingURL() {
-            let sut = makeSUT()
-            let storedData = anyData()
-            let matchingURL = URL(string: "http://a-url.com")!
-
-            insert(storedData, for: matchingURL, into: sut)
-
-            expect(sut, toCompleteRetrievalWith: found(storedData), for: matchingURL)
-        }
-
-        func test_retrieveImageData_deliversLastInsertedValue() {
-            let sut = makeSUT()
-            let firstStoredData = Data("first".utf8)
-            let lastStoredData = Data("last".utf8)
-            let url = URL(string: "http://a-url.com")!
-
-            insert(firstStoredData, for: url, into: sut)
-            insert(lastStoredData, for: url, into: sut)
-
-            expect(sut, toCompleteRetrievalWith: found(lastStoredData), for: url)
-        }
-
-        func test_sideEffects_runSerially() {
-            let sut = makeSUT()
-            let url = anyURL()
-
-            let op1 = expectation(description: "Operation 1")
-            sut.insert([localImage(url: url)], timestamp: Date()) { _ in
-                op1.fulfill()
-            }
-
-            let op2 = expectation(description: "Operation 2")
-            sut.insert(anyData(), for: url) { _ in    op2.fulfill() }
-
-            let op3 = expectation(description: "Operation 3")
-            sut.insert(anyData(), for: url) { _ in op3.fulfill() }
-
-            wait(for: [op1, op2, op3], timeout: 5.0, enforceOrder: true)
-        }
-
-        // - MARK: Helpers
+        let sut = makeSUT()
         
-        private func makeSUT(file: StaticString = #file, line: UInt = #line) -> CoreDataFeedStore {
-            let storeURL = URL(fileURLWithPath: "/dev/null")
-            let sut = try! CoreDataFeedStore(storeURL: storeURL)
-            checkIsDeallocated(sut: sut, file: file, line: line)
-            return sut
+        expect(sut, toCompleteRetrievalWith: notFound(), for: anyURL())
+    }
+    
+    func test_retrieveImageData_deliversNotFoundWhenStoredDataURLDoesNotMatch() {
+        let sut = makeSUT()
+        let url = URL(string: "http://a-url.com")!
+        let nonMatchingURL = URL(string: "http://another-url.com")!
+        
+        insert(anyData(), for: url, into: sut)
+        
+        expect(sut, toCompleteRetrievalWith: notFound(), for: nonMatchingURL)
+    }
+    
+    func test_retrieveImageData_deliversFoundDataWhenThereIsAStoredImageDataMatchingURL() {
+        let sut = makeSUT()
+        let storedData = anyData()
+        let matchingURL = URL(string: "http://a-url.com")!
+        
+        insert(storedData, for: matchingURL, into: sut)
+        
+        expect(sut, toCompleteRetrievalWith: found(storedData), for: matchingURL)
+    }
+    
+    func test_retrieveImageData_deliversLastInsertedValue() {
+        let sut = makeSUT()
+        let firstStoredData = Data("first".utf8)
+        let lastStoredData = Data("last".utf8)
+        let url = URL(string: "http://a-url.com")!
+        
+        insert(firstStoredData, for: url, into: sut)
+        insert(lastStoredData, for: url, into: sut)
+        
+        expect(sut, toCompleteRetrievalWith: found(lastStoredData), for: url)
+    }
+    
+    // - MARK: Helpers
+    
+    private func makeSUT(file: StaticString = #file, line: UInt = #line) -> CoreDataFeedStore {
+        let storeURL = URL(fileURLWithPath: "/dev/null")
+        let sut = try! CoreDataFeedStore(storeURL: storeURL)
+        checkIsDeallocated(sut: sut, file: file, line: line)
+        return sut
+    }
+    
+    private func notFound() -> Result<Data?, Error> {
+        return .success(.none)
+    }
+    
+    private func found(_ data: Data) -> Result<Data?, Error> {
+        return .success(data)
+    }
+    
+    private func localImage(url: URL) -> LocalFeedImage {
+        return LocalFeedImage(id: UUID(), description: "any", location: "any", url: url)
+    }
+    
+    private func expect(
+        _ sut: CoreDataFeedStore,
+        toCompleteRetrievalWith expectedResult: Result<Data?, Error>,
+        for url: URL,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) {
+        let receivedResult = Result { try sut.retrieve(dataForURL: url) }
+        switch (receivedResult, expectedResult) {
+        case let (.success( receivedData), .success(expectedData)):
+            XCTAssertEqual(receivedData, expectedData, file: file, line: line)
+            
+        default:
+            XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
         }
-
-        private func notFound() -> FeedImageDataStore.RetrievalResult {
-            return .success(.none)
-        }
-
-        private func found(_ data: Data) -> FeedImageDataStore.RetrievalResult {
-            return .success(data)
-        }
-
-        private func localImage(url: URL) -> LocalFeedImage {
-            return LocalFeedImage(id: UUID(), description: "any", location: "any", url: url)
-        }
-
-        private func expect(_ sut: CoreDataFeedStore, toCompleteRetrievalWith expectedResult: FeedImageDataStore.RetrievalResult, for url: URL,  file: StaticString = #file, line: UInt = #line) {
-            let exp = expectation(description: "Wait for load completion")
-            sut.retrieve(dataForURL: url) { receivedResult in
-                switch (receivedResult, expectedResult) {
-                case let (.success( receivedData), .success(expectedData)):
-                    XCTAssertEqual(receivedData, expectedData, file: file, line: line)
-
-                default:
-                    XCTFail("Expected \(expectedResult), got \(receivedResult) instead", file: file, line: line)
+    }
+    
+    private func insert(_ data: Data, for url: URL, into sut: CoreDataFeedStore, file: StaticString = #file, line: UInt = #line) {
+        let exp = expectation(description: "Wait for cache insertion")
+        let image = localImage(url: url)
+        sut.insert([image], timestamp: Date()) { error in
+            if let error {
+                XCTFail("Failed to save \(image) with error \(error)", file: file, line: line)
+                exp.fulfill()
+            } else {
+                do {
+                    try sut.insert(data, for: url)
+                } catch {
+                    XCTFail("Failed to insert \(data) with error \(error)", file: file, line: line)
                 }
                 exp.fulfill()
             }
-            wait(for: [exp], timeout: 1.0)
         }
-
-        private func insert(_ data: Data, for url: URL, into sut: CoreDataFeedStore, file: StaticString = #file, line: UInt = #line) {
-            let exp = expectation(description: "Wait for cache insertion")
-            let image = localImage(url: url)
-            sut.insert([image], timestamp: Date()) { error in
-                if let error {
-                    XCTFail("Failed to save \(image) with error \(error)", file: file, line: line)
-                    exp.fulfill()
-                } else {
-                    sut.insert(data, for: url) { result in
-                        if case let Result.failure(error) = result {
-                            XCTFail("Failed to insert \(data) with error \(error)", file: file, line: line)
-                        }
-                        exp.fulfill()
-                    }
-                }
-            }
-            wait(for: [exp], timeout: 1.0)
-        }
-
+        wait(for: [exp], timeout: 1.0)
+    }
+    
 }

--- a/EssentialFeedTests/Feed cache/CoreData/CoreDataFeedImageDataStoreTests.swift
+++ b/EssentialFeedTests/Feed cache/CoreData/CoreDataFeedImageDataStoreTests.swift
@@ -87,22 +87,12 @@ final class CoreDataFeedImageDataStoreTests: XCTestCase {
     }
     
     private func insert(_ data: Data, for url: URL, into sut: CoreDataFeedStore, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for cache insertion")
         let image = localImage(url: url)
-        sut.insert([image], timestamp: Date()) { error in
-            if let error {
-                XCTFail("Failed to save \(image) with error \(error)", file: file, line: line)
-                exp.fulfill()
-            } else {
-                do {
-                    try sut.insert(data, for: url)
-                } catch {
-                    XCTFail("Failed to insert \(data) with error \(error)", file: file, line: line)
-                }
-                exp.fulfill()
-            }
+        do {
+            try sut.insert([image], timestamp: Date())
+            try sut.insert(data, for: url)
+        } catch {
+            XCTFail("Failed to save \(image) with error \(error)", file: file, line: line)
         }
-        wait(for: [exp], timeout: 1.0)
     }
-    
 }

--- a/EssentialFeedTests/Feed cache/CoreData/CoreDataFeedStoreTests.swift
+++ b/EssentialFeedTests/Feed cache/CoreData/CoreDataFeedStoreTests.swift
@@ -76,12 +76,6 @@ class CoreDataFeedStoreTests: XCTestCase, FeedStoreSpecs {
         assertThatDeleteEmptiesPreviouslyInsertedCache(on: sut)
     }
 
-    func test_storeSideEffects_runSerially() {
-        let sut = makeSUT()
-
-        assertThatSideEffectsRunSerially(on: sut)
-    }
-
     // - MARK: Helpers
     
     private func makeSUT(file: StaticString = #file, line: UInt = #line) -> FeedStore {

--- a/EssentialFeedTests/Feed cache/Feed store specs/FeedStoreSpecs.swift
+++ b/EssentialFeedTests/Feed cache/Feed store specs/FeedStoreSpecs.swift
@@ -23,8 +23,6 @@ protocol FeedStoreSpecs {
     func test_delete_hasNoSideEffectsOnEmptyCache()
     func test_delete_deliversNoErrorOnNonEmptyCache()
     func test_delete_emptiesPreviouslyInsertedCache()
-    
-    func test_storeSideEffects_runSerially()
 }
 
 protocol FailableRetrieveFeedStoreSpecs: FeedStoreSpecs {

--- a/EssentialFeedTests/Feed cache/Feed store specs/XCTestCase+FeedStoreSpecs.swift
+++ b/EssentialFeedTests/Feed cache/Feed store specs/XCTestCase+FeedStoreSpecs.swift
@@ -9,163 +9,127 @@ import XCTest
 import EssentialFeed
 
 extension FeedStoreSpecs where Self: XCTestCase {
-
+    
     func assertThatRetrieveDeliversEmptyOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
         expect(sut, toRetrieve: .success(.none), file: file, line: line)
     }
-
+    
     func assertThatRetrieveHasNoSideEffectsOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
         expect(sut, toRetrieveTwice: .success(.none), file: file, line: line)
     }
-
+    
     func assertThatRetrieveDeliversFoundValuesOnNonEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
         let feed = uniqueImageFeed().local
         let timestamp = Date()
-
+        
         insert((feed, timestamp), to: sut)
-
+        
         expect(sut, toRetrieve: .success(.some((feed, timestamp))), file: file, line: line)
     }
-
+    
     func assertThatRetrieveHasNoSideEffectsOnNonEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
         let feed = uniqueImageFeed().local
         let timestamp = Date()
-
+        
         insert((feed, timestamp), to: sut)
-
+        
         expect(sut, toRetrieveTwice: .success((feed, timestamp)), file: file, line: line)
     }
-
+    
     func assertThatInsertDeliversNoErrorOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
         let insertionError = insert((uniqueImageFeed().local, Date()), to: sut)
-
+        
         XCTAssertNil(insertionError, "Expected to insert cache successfully", file: file, line: line)
     }
-
+    
     func assertThatInsertDeliversNoErrorOnNonEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
         insert((uniqueImageFeed().local, Date()), to: sut)
-
+        
         let insertionError = insert((uniqueImageFeed().local, Date()), to: sut)
-
+        
         XCTAssertNil(insertionError, "Expected to override cache successfully", file: file, line: line)
     }
-
+    
     func assertThatInsertOverridesPreviouslyInsertedCacheValues(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
         insert((uniqueImageFeed().local, Date()), to: sut)
-
+        
         let latestFeed = uniqueImageFeed().local
         let latestTimestamp = Date()
         insert((latestFeed, latestTimestamp), to: sut)
-
+        
         expect(sut, toRetrieve: .success((latestFeed, latestTimestamp)), file: file, line: line)
     }
-
+    
     func assertThatDeleteDeliversNoErrorOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
         let deletionError = deleteCache(from: sut)
-
+        
         XCTAssertNil(deletionError, "Expected empty cache deletion to succeed", file: file, line: line)
     }
-
+    
     func assertThatDeleteHasNoSideEffectsOnEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
         deleteCache(from: sut)
-
+        
         expect(sut, toRetrieve: .success(nil), file: file, line: line)
     }
-
+    
     func assertThatDeleteDeliversNoErrorOnNonEmptyCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
         insert((uniqueImageFeed().local, Date()), to: sut)
-
+        
         let deletionError = deleteCache(from: sut)
-
+        
         XCTAssertNil(deletionError, "Expected non-empty cache deletion to succeed", file: file, line: line)
     }
-
+    
     func assertThatDeleteEmptiesPreviouslyInsertedCache(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
         insert((uniqueImageFeed().local, Date()), to: sut)
-
+        
         deleteCache(from: sut)
-
+        
         expect(sut, toRetrieve: .success(nil), file: file, line: line)
     }
-
-    func assertThatSideEffectsRunSerially(on sut: FeedStore, file: StaticString = #file, line: UInt = #line) {
-        var completedOperationsInOrder = [XCTestExpectation]()
-
-        let op1 = expectation(description: "Operation 1")
-        sut.insert(uniqueImageFeed().local, timestamp: Date()) { _ in
-            completedOperationsInOrder.append(op1)
-            op1.fulfill()
-        }
-
-        let op2 = expectation(description: "Operation 2")
-        sut.deleteCachedFeed { _ in
-            completedOperationsInOrder.append(op2)
-            op2.fulfill()
-        }
-
-        let op3 = expectation(description: "Operation 3")
-        sut.insert(uniqueImageFeed().local, timestamp: Date()) { _ in
-            completedOperationsInOrder.append(op3)
-            op3.fulfill()
-        }
-
-        waitForExpectations(timeout: 5.0)
-
-        XCTAssertEqual(completedOperationsInOrder, [op1, op2, op3], "Expected side-effects to run serially but operations finished in the wrong order", file: file, line: line)
-    }
-
 }
 
 extension FeedStoreSpecs where Self: XCTestCase {
     @discardableResult
     func insert(_ cache: (feed: [LocalFeedImage], timestamp: Date), to sut: FeedStore) -> Error? {
-        let exp = expectation(description: "Wait for cache insertion")
         var insertionError: Error?
-        sut.insert(cache.feed, timestamp: cache.timestamp) { receivedInsertionError in
-            insertionError = receivedInsertionError
-            exp.fulfill()
+        do {
+            try sut.insert(cache.feed, timestamp: cache.timestamp)
+        } catch {
+            insertionError = error
         }
-        wait(for: [exp], timeout: 1.0)
         return insertionError
     }
-
+    
     @discardableResult
     func deleteCache(from sut: FeedStore) -> Error? {
-        let exp = expectation(description: "Wait for cache deletion")
         var deletionError: Error?
-        sut.deleteCachedFeed { receivedDeletionError in
-            deletionError = receivedDeletionError
-            exp.fulfill()
+        do {
+            try sut.deleteCachedFeed()
+        } catch {
+            deletionError = error
         }
-        wait(for: [exp], timeout: 1.0)
         return deletionError
     }
-
-    func expect(_ sut: FeedStore, toRetrieveTwice expectedResult: FeedStore.RetrievalResult, file: StaticString = #file, line: UInt = #line) {
+    
+    func expect(_ sut: FeedStore, toRetrieveTwice expectedResult: Result<CachedFeed?, Error>, file: StaticString = #file, line: UInt = #line) {
         expect(sut, toRetrieve: expectedResult, file: file, line: line)
         expect(sut, toRetrieve: expectedResult, file: file, line: line)
     }
-
-    func expect(_ sut: FeedStore, toRetrieve expectedResult: FeedStore.RetrievalResult, file: StaticString = #file, line: UInt = #line) {
-        let exp = expectation(description: "Wait for cache retrieval")
-
-        sut.retrieve { retrievedResult in
-            switch (expectedResult, retrievedResult) {
-            case (.success(.none), .success(.none)),
-                 (.failure, .failure):
-                break
-
-            case let (.success(.some(expected)), .success(.some(retrieved))):
-                XCTAssertEqual(retrieved.feed, expected.feed, file: file, line: line)
-                XCTAssertEqual(retrieved.timestamp, expected.timestamp, file: file, line: line)
-
-            default:
-                XCTFail("Expected to retrieve \(expectedResult), got \(retrievedResult) instead", file: file, line: line)
-            }
-
-            exp.fulfill()
+    
+    func expect(_ sut: FeedStore, toRetrieve expectedResult: Result<CachedFeed?, Error>, file: StaticString = #file, line: UInt = #line) {
+        let retrievedResult = Result { try sut.retrieve() }
+        switch (expectedResult, retrievedResult) {
+        case (.success(.none), .success(.none)),
+            (.failure, .failure):
+            break
+            
+        case let (.success(.some(expected)), .success(.some(retrieved))):
+            XCTAssertEqual(retrieved.feed, expected.feed, file: file, line: line)
+            XCTAssertEqual(retrieved.timestamp, expected.timestamp, file: file, line: line)
+            
+        default:
+            XCTFail("Expected to retrieve \(expectedResult), got \(retrievedResult) instead", file: file, line: line)
         }
-
-        wait(for: [exp], timeout: 1.0)
     }
 }

--- a/EssentialFeedTests/Feed cache/Helpers/FeedImageDataStoreSpy.swift
+++ b/EssentialFeedTests/Feed cache/Helpers/FeedImageDataStoreSpy.swift
@@ -15,12 +15,12 @@ class FeedImageDataStoreSpy: FeedImageDataStore {
     }
     
     private(set) var messages: [Message] = []
-    private var insertionCompletions: [(InsertionResult) -> Void] = []
+    private var insertionResult: Result<Void, Error>?
     private var retrievalCompletions: [(RetrievalResult) -> Void] = []
     
-    func insert(_ data: Data, for url: URL, completion: @escaping (InsertionResult) -> Void) {
+    func insert(_ data: Data, for url: URL) throws -> Void {
         messages.append(.insert(data: data, url: url))
-        insertionCompletions.append(completion)
+        try insertionResult?.get()
     }
     
     func retrieve(dataForURL url: URL, completion: @escaping (RetrievalResult) -> Void) {
@@ -28,12 +28,12 @@ class FeedImageDataStoreSpy: FeedImageDataStore {
         retrievalCompletions.append(completion)
     }
     
-    func completeInsertionSuccessfully(at index: Int = 0) {
-        insertionCompletions[index](.success(()))
+    func completeInsertionSuccessfully() {
+        insertionResult = .success(())
     }
     
-    func completeInsertion(error: Error, at index: Int = 0) {
-        insertionCompletions[index](.failure(error))
+    func completeInsertion(error: Error) {
+        insertionResult = .failure(error)
     }
     
     func completeRetrievalSuccessfully(data: Data?, at index: Int = 0) {

--- a/EssentialFeedTests/Feed cache/Helpers/FeedImageDataStoreSpy.swift
+++ b/EssentialFeedTests/Feed cache/Helpers/FeedImageDataStoreSpy.swift
@@ -16,16 +16,16 @@ class FeedImageDataStoreSpy: FeedImageDataStore {
     
     private(set) var messages: [Message] = []
     private var insertionResult: Result<Void, Error>?
-    private var retrievalCompletions: [(RetrievalResult) -> Void] = []
+    private var retrievalResult: Result<Data?, Error>?
     
     func insert(_ data: Data, for url: URL) throws -> Void {
         messages.append(.insert(data: data, url: url))
         try insertionResult?.get()
     }
     
-    func retrieve(dataForURL url: URL, completion: @escaping (RetrievalResult) -> Void) {
+    func retrieve(dataForURL url: URL) throws -> Data? {
         messages.append(.retrieve(url: url))
-        retrievalCompletions.append(completion)
+        return try retrievalResult?.get()
     }
     
     func completeInsertionSuccessfully() {
@@ -36,11 +36,11 @@ class FeedImageDataStoreSpy: FeedImageDataStore {
         insertionResult = .failure(error)
     }
     
-    func completeRetrievalSuccessfully(data: Data?, at index: Int = 0) {
-        retrievalCompletions[index](.success(data))
+    func completeRetrievalSuccessfully(data: Data?) {
+        retrievalResult = .success(data)
     }
     
-    func completeRetrieval(error: Error, at index: Int = 0) {
-        retrievalCompletions[index](.failure(error))
+    func completeRetrieval(error: Error) {
+        retrievalResult = .failure(error)
     }
 }

--- a/EssentialFeedTests/Feed cache/LocalFeedImageDataLoaderTests+Load.swift
+++ b/EssentialFeedTests/Feed cache/LocalFeedImageDataLoaderTests+Load.swift
@@ -9,7 +9,7 @@ import XCTest
 import EssentialFeed
 
 final class LocalFeedImageDataLoaderTests_Load: XCTestCase {
-
+    
     func test_init_doesNotMessageStore() {
         let (_, store) = makeSUT()
         
@@ -20,7 +20,7 @@ final class LocalFeedImageDataLoaderTests_Load: XCTestCase {
         let (sut, store) = makeSUT()
         let someURL = anyURL()
         
-        _ = sut.load(from: someURL) { _ in }
+        _ = try? sut.load(from: someURL)
         
         XCTAssertEqual(store.messages, [.retrieve(url: someURL)])
     }
@@ -60,32 +60,28 @@ final class LocalFeedImageDataLoaderTests_Load: XCTestCase {
         return (sut, store)
     }
     
-    private func loaderError(_ error: LocalFeedImageDataLoader.LoadError) -> LocalFeedImageDataLoader.LoadResult {
+    private func loaderError(_ error: LocalFeedImageDataLoader.LoadError) -> Result<Data, Error> {
         .failure(error)
     }
     
     private func expect(
         _ sut: LocalFeedImageDataLoader,
-        toLoadWith expectedResult: LocalFeedImageDataLoader.LoadResult,
+        toLoadWith expectedResult: Result<Data, Error>,
         when action: () -> Void,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
         action()
-        let exp = expectation(description: "wait for load")
-        _ = sut.load(from: anyURL()) { receivedResult in
-            switch (expectedResult, receivedResult) {
-            case (.success(let expectedData), .success(let receivedData)):
-                XCTAssertEqual(expectedData, receivedData, file: file, line: line)
-            case (.failure(let expectedError as LocalFeedImageDataLoader.LoadError), .failure(let receivedError as LocalFeedImageDataLoader.LoadError)):
-                XCTAssertEqual(expectedError, receivedError, file: file, line: line)
-            case (.failure(let expectedError as NSError), .failure(let receivedError as NSError)):
-                XCTAssertEqual(expectedError, receivedError, file: file, line: line)
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult)", file: file, line: line)
-            }
-            exp.fulfill()
+        let receivedResult = Result { try sut.load(from: anyURL()) }
+        switch (expectedResult, receivedResult) {
+        case (.success(let expectedData), .success(let receivedData)):
+            XCTAssertEqual(expectedData, receivedData, file: file, line: line)
+        case (.failure(let expectedError as LocalFeedImageDataLoader.LoadError), .failure(let receivedError as LocalFeedImageDataLoader.LoadError)):
+            XCTAssertEqual(expectedError, receivedError, file: file, line: line)
+        case (.failure(let expectedError as NSError), .failure(let receivedError as NSError)):
+            XCTAssertEqual(expectedError, receivedError, file: file, line: line)
+        default:
+            XCTFail("Expected \(expectedResult), got \(receivedResult)", file: file, line: line)
         }
-        wait(for: [exp], timeout: 1)
     }
 }

--- a/EssentialFeedTests/Feed cache/LocalFeedImageDataLoaderTests+Load.swift
+++ b/EssentialFeedTests/Feed cache/LocalFeedImageDataLoaderTests+Load.swift
@@ -50,34 +50,6 @@ final class LocalFeedImageDataLoaderTests_Load: XCTestCase {
         })
     }
     
-    func test_load_doesNotDeliverResultAfterCancellingTask() {
-        let (sut, store) = makeSUT()
-        let foundData = anyData()
-
-        var received = [FeedImageDataLoader.Result]()
-        let task = sut.load(from: anyURL()) { received.append($0) }
-        task.cancel()
-
-        store.completeRetrievalSuccessfully(data: foundData)
-        store.completeRetrievalSuccessfully(data: nil)
-        store.completeRetrieval(error: anyNSError())
-
-        XCTAssertTrue(received.isEmpty, "Expected no received results after cancelling task")
-    }
-    
-    func test_load_doesNotDeliverResultAfterSUTInstanceHasBeenDeallocated() {
-            let store = FeedImageDataStoreSpy()
-            var sut: LocalFeedImageDataLoader? = LocalFeedImageDataLoader(store: store)
-
-            var received = [FeedImageDataLoader.Result]()
-            _ = sut?.load(from: anyURL()) { received.append($0) }
-
-            sut = nil
-            store.completeRetrievalSuccessfully(data: anyData())
-
-            XCTAssertTrue(received.isEmpty, "Expected no received results after instance has been deallocated")
-        }
-    
     // MARK: - Helpers
     
     private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> (sut: LocalFeedImageDataLoader, store: FeedImageDataStoreSpy) {
@@ -99,6 +71,7 @@ final class LocalFeedImageDataLoaderTests_Load: XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
+        action()
         let exp = expectation(description: "wait for load")
         _ = sut.load(from: anyURL()) { receivedResult in
             switch (expectedResult, receivedResult) {
@@ -113,7 +86,6 @@ final class LocalFeedImageDataLoaderTests_Load: XCTestCase {
             }
             exp.fulfill()
         }
-        action()
         wait(for: [exp], timeout: 1)
     }
 }

--- a/EssentialFeedTests/Feed cache/LocalFeedImageDataLoaderTests+Save.swift
+++ b/EssentialFeedTests/Feed cache/LocalFeedImageDataLoaderTests+Save.swift
@@ -42,18 +42,6 @@ final class LocalFeedImageDataLoaderTests_Save: XCTestCase {
         })
     }
     
-    func test_save_doesNotCompleteAfterItWasDeallocated() {
-        let store = FeedImageDataStoreSpy()
-        var sut: LocalFeedImageDataLoader? = LocalFeedImageDataLoader(store: store)
-        
-        var receivedResults: [LocalFeedImageDataLoader.SaveResult] = []
-        sut?.save(anyData(), for: anyURL()) { receivedResults.append($0) }
-        sut = nil
-        store.completeInsertionSuccessfully()
-        
-        XCTAssertTrue(receivedResults.isEmpty)
-    }
-    
     // MARK: - Helpers
     
     private func makeSUT(file: StaticString = #filePath, line: UInt = #line) -> (sut: LocalFeedImageDataLoader, store: FeedImageDataStoreSpy) {
@@ -76,6 +64,7 @@ final class LocalFeedImageDataLoaderTests_Save: XCTestCase {
         line: UInt = #line
     ) {
         let exp = expectation(description: "wait for save")
+        action()
         sut.save(anyData(), for: anyURL()) { receivedResult in
             switch (expectedResult, receivedResult) {
             case (.success, .success):
@@ -89,7 +78,6 @@ final class LocalFeedImageDataLoaderTests_Save: XCTestCase {
             }
             exp.fulfill()
         }
-        action()
         wait(for: [exp], timeout: 1)
     }
 }

--- a/EssentialFeedTests/Feed cache/LocalFeedImageDataLoaderTests+Save.swift
+++ b/EssentialFeedTests/Feed cache/LocalFeedImageDataLoaderTests+Save.swift
@@ -16,12 +16,12 @@ final class LocalFeedImageDataLoaderTests_Save: XCTestCase {
         XCTAssertTrue(store.messages.isEmpty)
     }
     
-    func test_save_sendsSaveMessageToStore() {
+    func test_save_sendsSaveMessageToStore() throws {
         let (sut, store) = makeSUT()
         let someData = anyData()
         let someURL = anyURL()
         
-        sut.save(someData, for: someURL) { _ in }
+        try sut.save(someData, for: someURL)
         
         XCTAssertEqual(store.messages, [.insert(data: someData, url: someURL)])
     }
@@ -52,32 +52,28 @@ final class LocalFeedImageDataLoaderTests_Save: XCTestCase {
         return (sut, store)
     }
     
-    private func failed() -> LocalFeedImageDataLoader.SaveResult {
+    private func failed() -> Result<Void, Error> {
         .failure(LocalFeedImageDataLoader.SaveError.failed)
     }
     
     private func expect(
         _ sut: LocalFeedImageDataLoader,
-        toSaveWith expectedResult: LocalFeedImageDataLoader.SaveResult,
+        toSaveWith expectedResult: Result<Void, Error>,
         when action: () -> Void,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        let exp = expectation(description: "wait for save")
         action()
-        sut.save(anyData(), for: anyURL()) { receivedResult in
-            switch (expectedResult, receivedResult) {
-            case (.success, .success):
-                break
-            case (.failure(let expectedError as LocalFeedImageDataLoader.SaveError), .failure(let receivedError as LocalFeedImageDataLoader.SaveError)):
-                XCTAssertEqual(expectedError, receivedError, file: file, line: line)
-            case (.failure(let expectedError as NSError), .failure(let receivedError as NSError)):
-                XCTAssertEqual(expectedError, receivedError, file: file, line: line)
-            default:
-                XCTFail("Expected \(expectedResult), got \(receivedResult)", file: file, line: line)
-            }
-            exp.fulfill()
+        let receivedResult = Result { try sut.save(anyData(), for: anyURL()) }
+        switch (expectedResult, receivedResult) {
+        case (.success, .success):
+            break
+        case (.failure(let expectedError as LocalFeedImageDataLoader.SaveError), .failure(let receivedError as LocalFeedImageDataLoader.SaveError)):
+            XCTAssertEqual(expectedError, receivedError, file: file, line: line)
+        case (.failure(let expectedError as NSError), .failure(let receivedError as NSError)):
+            XCTAssertEqual(expectedError, receivedError, file: file, line: line)
+        default:
+            XCTFail("Expected \(expectedResult), got \(receivedResult)", file: file, line: line)
         }
-        wait(for: [exp], timeout: 1)
     }
 }

--- a/EssentialFeediOS/Feed UI/Controllers/FeedCellController.swift
+++ b/EssentialFeediOS/Feed UI/Controllers/FeedCellController.swift
@@ -82,6 +82,7 @@ extension FeedCellController: UITableViewDataSource, UITableViewDelegate, UITabl
     }
     
     private func releaseCellReference() {
+        cell?.onPrepareForReuse = nil
         cell = nil
     }
     


### PR DESCRIPTION
Remove async FeedStore and FeedImageDataStore implementations in favour of sync methods + handle threading into composition root via `subscribe(on:)` method in Combine